### PR TITLE
feat: added a cost breakdown per company

### DIFF
--- a/economy.nut
+++ b/economy.nut
@@ -18,7 +18,7 @@ class Economy
             foreach(company in economy_data.companies) 
             {
                 if(!("dividend_rate" in company)) company.dividend_rate <- 0;
-                this.companies_list.append(Company(company.id, company.bank_bal, company.loan, company.dividend_rate));
+                this.companies_list.append(Company(company.id, company.bank_bal, company.loan, company.dividend_rate, company.story_page_id));
             }
         }
     }
@@ -42,7 +42,7 @@ class Economy
     {
         if(GSCompany.ResolveCompanyID(id) != GSCompany.COMPANY_INVALID) {
             local mode = GSCompanyMode(id);
-            this.companies_list.append(Company(id, GSCompany.GetBankBalance(id),  GSCompany.GetLoanAmount(), 0));
+            this.companies_list.append(Company(id, GSCompany.GetBankBalance(id),  GSCompany.GetLoanAmount(), 0, -1));
         }
     }
 

--- a/lang/english.txt
+++ b/lang/english.txt
@@ -21,3 +21,5 @@ STR_CONCAT_3 :{STRING1}{STRING1}{STRING1}
 STR_CONCAT_4 :{STRING}{STRING1}{STRING1}{STRING1}
 STR_DIVIDEND :{COMPANY} has paid {NUM}% dividend to its shareholders this year, totalling {COMMA}.
 STR_NO_DIVIDEND :{COMPANY} will not issue a dividend this year.
+STR_COST_BREAKDOWN_DIVIDEND :Dividend ({NUM}%): {COMMA}
+STR_COST_BREAKDOWN_TAX :Taxes: {COMMA}


### PR DESCRIPTION
Still need to run and test this for a bit.

Something else that might be worth looking into is showing the dates in descending order in the storybook. 

I don't know if that is possible, but I can imagine having a large list of 50 + years to scroll through will not be ideal
 - I do not see a way of doing this other than removing all the elements every time a new year will be added, and then adding the elements back in the desired order.

Element limit is currently being hit after 42 years. I will have to group the years by pages or something.
